### PR TITLE
link the abstract_subexpr.so to mirage library (#286)

### DIFF
--- a/.github/workflows/helpers/install_dependencies.sh
+++ b/.github/workflows/helpers/install_dependencies.sh
@@ -42,3 +42,9 @@ sudo rm -rf /var/lib/apt/lists/*
 curl https://sh.rustup.rs -sSf | sh -s -- -y
 # shellcheck source=/dev/null
 . "$HOME/.cargo/env"
+
+# Make sure abstract_subexpr lib is found
+LIB_PATH=$(realpath ./src/search/abstract_expr/abstract_subexpr/target/release/libabstract_subexpr.so)
+sudo cp "$LIB_PATH" /usr/lib/
+sudo ln -sf /usr/lib/libabstract_subexpr.so /usr/lib/libabstract_subexpr.so.1.0
+sudo ldconfig

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,26 +137,14 @@ if(NOT CARGO_RESULT EQUAL 0)
 endif()
 
 #set RUST
-include(ExternalProject)
-
-set(RUST_CRATE_DIR "${PROJECT_SOURCE_DIR}/src/search/abstract_expr/abstract_subexpr")
-set(RUST_LIB_DEBUG "${RUST_CRATE_DIR}/target/debug/libabstract_subexpr.so")
-set(RUST_LIB_RELEASE "${RUST_CRATE_DIR}/target/release/libabstract_subexpr.so")
-
-set_directory_properties(PROPERTIES EP_PREFIX ${PROJECT_SOURCE_DIR}/deps/Rust)
-ExternalProject_Add(
-  abstract_subexpr
-  DOWNLOAD_COMMAND ""
-  CONFIGURE_COMMAND ""
-  BUILD_COMMAND cargo build --release
-  BINARY_DIR "${RUST_CRATE_DIR}"
-  INSTALL_COMMAND ""
-  LOG_BUILD ON)
-
-add_dependencies(mirage_runtime abstract_subexpr)
-
-target_link_libraries(mirage_runtime
-  optimized ${RUST_LIB_RELEASE})
+if(ABSTRACT_SUBEXPR_LIB AND ABSTRACT_SUBEXPR_LIBRARIES)
+  message(STATUS "ABSTRACT_SUBEXPR_LIB: ${ABSTRACT_SUBEXPR_LIB}")
+  message(STATUS "ABSTRACT_SUBEXPR_LIBRARIES: ${ABSTRACT_SUBEXPR_LIBRARIES}")
+else()
+  message(STATUS "ABSTRACT_SUBEXPR_LIB not set, will build it")
+endif()
+include_directories(${ABSTRACT_SUBEXPR_LIB})
+list(APPEND MIRAGE_LINK_LIBS ${ABSTRACT_SUBEXPR_LIBRARIES})
 
 set_target_properties(mirage_runtime PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
 
@@ -174,6 +162,9 @@ install(TARGETS mirage_runtime
 
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/include
     DESTINATION .)
+
+install(FILES ${ABSTRACT_SUBEXPR_LIBRARIES} 
+    DESTINATION lib)
 
 if ("${BUILD_CPP_EXAMPLES}" STREQUAL "ON")
   set(CPP_EXAMPLES_DIR cpp_examples)

--- a/python/mirage/__init__.py
+++ b/python/mirage/__init__.py
@@ -1,18 +1,23 @@
 import os
+import ctypes
+import z3
 
-try:
-    from .core import *
-except ImportError:
-    import z3
-    _z3_lib = os.path.join(os.path.dirname(z3.__file__), 'lib')
-    os.environ['LD_LIBRARY_PATH'] = f"{_z3_lib}:{os.environ.get('LD_LIBRARY_PATH','LD_LIBRARY_PATH')}"
+def preload_so(lib_path, name_hint):
+    try:
+        ctypes.CDLL(lib_path)
+    except OSError as e:
+        raise ImportError(f"Could not preload {name_hint} ({lib_path}): {e}")
 
-    rust_path = os.path.join('/'.join(os.path.dirname(__file__).split('/')[:-2]), 'src', 'search', 'abstract_expr', 'abstract_subexpr', 'target', 'release')
-    if not rust_path in os.environ['LD_LIBRARY_PATH']:
-        os.environ['LD_LIBRARY_PATH'] += ':'+rust_path
+_z3_libdir = os.path.join(os.path.dirname(z3.__file__), "lib")
+_z3_so_path = os.path.join(_z3_libdir, "libz3.so")
+preload_so(_z3_so_path, "libz3.so")
 
-    
-    from .core import *
+_this_dir = os.path.dirname(__file__)
+_mirage_root = os.path.abspath(os.path.join(_this_dir, "..", ".."))
+_rust_so_path = os.path.join(_mirage_root, "src", "search", "abstract_expr", "abstract_subexpr", "target", "release", "libabstract_subexpr.so")
+preload_so(_rust_so_path, "libabstract_subexpr.so")
+
+from .core import *
 
 from .kernel import *
 from .threadblock import *

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ def config_cython():
                               path.join(mirage_path, "deps", "json", "include"),
                               path.join(mirage_path, "deps", "cutlass", "include"),
                               path.join(z3_path, "include"),
+                              path.join(mirage_path, "src", "search", "abstract_expr", "abstract_subexpr", "target", "release"),
                               "/usr/local/cuda/include"],
                 libraries=["mirage_runtime", "cudadevrt", "cudart_static", "cudnn", "cublas", "cudart", "cuda", "z3", "gomp", "abstract_subexpr"],
                 library_dirs=[path.join(mirage_path, "build"),
@@ -64,22 +65,53 @@ def config_cython():
                               "/usr/local/cuda/lib64",
                               "/usr/local/cuda/lib64/stubs"],
                 extra_compile_args=["-std=c++17", "-fopenmp"],
-                extra_link_args=["-fPIC", "-fopenmp"],
+                extra_link_args=[
+                    "-fPIC",
+                    "-fopenmp",
+                    f"-Wl,-rpath,{path.join(mirage_path, 'src', 'search', 'abstract_expr', 'abstract_subexpr', 'target', 'release')}"
+                ],
                 language="c++"))
         return cythonize(ret, compiler_directives={"language_level" : 3})
     except ImportError:
         print("WARNING: cython is not installed!!!")
         raise SystemExit(1)
+    
+# Install Rust if not yet available
+try:
+    # Attempt to run a Rust command to check if Rust is installed
+    subprocess.check_output(['cargo', '--version'])
+except FileNotFoundError:
+    print("Rust/Cargo not found, installing it...")
+    # Rust is not installed, so install it using rustup
+    try:
+        subprocess.run("curl https://sh.rustup.rs -sSf | sh -s -- -y", shell=True, check=True)
+        print("Rust and Cargo installed successfully.")
+    except subprocess.CalledProcessError as e:
+        print(f"Error: {e}")
+    # Add the cargo binary directory to the PATH
+    os.environ["PATH"] = f"{os.path.join(os.environ.get('HOME', '/root'), '.cargo', 'bin')}:{os.environ.get('PATH', '')}"
+
+mirage_path = path.dirname(__file__)
+# z3_path = os.path.join(mirage_path, 'deps', 'z3', 'build')
+# os.environ['Z3_DIR'] = z3_path
+if mirage_path == '':
+    mirage_path = '.'
+
+try:
+    subprocess.check_output(['cargo', 'build', '--release'], cwd='src/search/abstract_expr/abstract_subexpr')
+except subprocess.CalledProcessError as e:
+    print("Failed to build abstract_subexpr Rust library, building it ...")
+    try:
+        subprocess.run(['cargo', 'build', '--release'], cwd='src/search/abstract_expr/abstract_subexpr', check=True)
+        print("Abstract_subexpr Rust library built successfully.")
+    except subprocess.CalledProcessError as e:
+        print("Failed to build abstract_subexpr Rust library.")
+    os.environ['ABSTRACT_SUBEXPR_LIB'] = os.path.join(mirage_path,'src', 'search', 'abstract_expr', 'abstract_subexpr', 'target', 'release', 'libabstract_subexpr.so')
 
 # build Mirage runtime library
 try:
     nvcc_path = shutil.which('nvcc')
     os.environ['CUDACXX'] = nvcc_path if nvcc_path else '/usr/local/cuda/bin/nvcc'
-    mirage_path = path.dirname(__file__)
-    # z3_path = os.path.join(mirage_path, 'deps', 'z3', 'build')
-    # os.environ['Z3_DIR'] = z3_path
-    if mirage_path == '':
-        mirage_path = '.'
     os.makedirs(mirage_path, exist_ok=True)
     os.chdir(mirage_path)
     build_dir = os.path.join(mirage_path, 'build')
@@ -95,6 +127,8 @@ try:
     subprocess.check_call(['cmake', '..',
                            '-DZ3_CXX_INCLUDE_DIRS=' + z3_path + '/include/',
                            '-DZ3_LIBRARIES=' + path.join(z3_path, 'lib', 'libz3.so'),
+                           '-DABSTRACT_SUBEXPR_LIB=' + path.join(mirage_path, 'src', 'search', 'abstract_expr', 'abstract_subexpr', 'target', 'release'),
+                           '-DABSTRACT_SUBEXPR_LIBRARIES=' + path.join(mirage_path, 'src', 'search', 'abstract_expr', 'abstract_subexpr', 'target', 'release', 'libabstract_subexpr.so'),
                            '-DCMAKE_C_COMPILER=' + os.environ['CC'],
                            '-DCMAKE_CXX_COMPILER=' + os.environ['CXX'],
                           ], cwd=build_dir, env=os.environ.copy())


### PR DESCRIPTION
* egg_part

* egg_subpattern_to

* add_some_operators_for_egg

* add_square_for_egg

* new_subpattern_to

* subpattern_to

* new_subpattern_to

* egg_part

* Update chameleon-7b.py

* Update chameleon.py

* Update rms_norm.py

* Update mirage_search_checkpoint.json

* Update mirage_search_checkpoint.json

* Delete demo/verification_tests/mirage_search_checkpoint.json

* Update type.h

* Delete src/search/abstract_expr/abstract_subexpr/egg_tests.cpp

* egraph construction at beginning

* Delete cpp_examples/subpattern_to.cc

* Delete demo/verification_tests/gated_mlp_verifier.py

* Delete demo/verification_tests/lora_verifier.py

* Delete demo/verification_tests/rms_norm_verifier.py

* clear some template files

* ensure cargo and rust install

* ensure cargo and rust install

* change std::unordered_map to vector

* Update abstract_expr.h

* add ci tests

* solve issue#284

* solve issue #284

* solve issue #284

* solve issue#284

* solve issue#284

* solve issue#284

* solve issue#284

* solve issue#284

---------

**Description of changes:**



**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #


